### PR TITLE
Four changes to [conversions.string]

### DIFF
--- a/source/locales.tex
+++ b/source/locales.tex
@@ -1134,12 +1134,13 @@ An object of this class template stores:
 \indexlibrary{\idxcode{byte_string}!\idxcode{wstring_convert}}%
 \indexlibrary{\idxcode{wstring_convert}!\idxcode{byte_string}}%
 \begin{itemdecl}
-typedef std::basic_string<char> byte_string;
+typedef std::basic_string<char, char_traits<char>, Byte_alloc> byte_string;
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-The type shall be a synonym for \tcode{std::basic_string<char>}
+The type shall be a synonym for \tcode{std::basic_string<char,
+char_traits<char>, Byte_alloc>}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{converted}!\idxcode{wstring_convert}}%
@@ -1264,12 +1265,13 @@ Otherwise, the member function shall throw an object of class \tcode{std::range_
 \indexlibrary{\idxcode{wide_string}!\idxcode{wstring_convert}}%
 \indexlibrary{\idxcode{wstring_convert}!\idxcode{wide_string}}%
 \begin{itemdecl}
-typedef std::basic_string<Elem> wide_string;
+typedef std::basic_string<Elem, char_traits<Elem>, Wide_alloc> wide_string;
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-The type shall be a synonym for \tcode{std::basic_string<Elem>}.
+The type shall be a synonym for \tcode{std::basic_string<Elem,
+char_traits<Elem>, Wide_alloc>}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{wstring_convert}!constructor}%


### PR DESCRIPTION
The example supposes the existence of some facet called `codecvt_utf8`, which is in the standard library so there's no need to word it that way.

The types `byte_string` and `wide_string` should be in a fixed-width typeface.

`Codecvt` is not a template, so `Codecvt<Elem, char, std::mbstate_t>` is ill-formed.

The definitions for the `byte_string` and `wide_string` typedefs don't seem to have been updated to use allocators, so don't match the class synopsis (are those definitions even necessary? They don't add anything that isn't already defined in the class definition in paragraph 2).

There are also lots of redundant `std::` qualifications in that clause, which I didn't remove to keep the patch simpler.

If any of these doesn't qualify as editorial changes let me know and I'll request LWG issues and send a new pull request without those parts.
